### PR TITLE
feat(Frontend): Put username from login to cookies, display username on home page

### DIFF
--- a/frontend/src/routes/home/+page.svelte
+++ b/frontend/src/routes/home/+page.svelte
@@ -1,7 +1,15 @@
 <script>
 	import TitleText from "$lib/components/TitleText.svelte";
 
-    let username = "testuser"
+    
+    let cookieString = document.cookie;
+    let pairs = cookieString.split(";");
+    let splittedPairs = pairs.map(cookie => cookie.split("="));
+    const cookieObj = splittedPairs.reduce(function (obj, cookie) {
+        obj[cookie[0]] = cookie[1];
+    return obj;
+    }, {})
+    let username = cookieObj["username"];
 </script>
 
 <TitleText text={`Welcome, ${username}!`}/>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -42,6 +42,7 @@
         alert(message)
       } else {
         setAuth(true)
+        document.cookie = `username=${username}`;
         goto('/home') 
       }
       


### PR DESCRIPTION
## 📌 Summary
Put username from login to cookies, display username on home page

## ✅ Proposed Changes
  - username cookie set in login svelte page
  - home svelte page displays username from cookie